### PR TITLE
feat(cita-timeline): flujo guiado Historia→Odontograma + cierre; soporte version_token y modo solo-lectura

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,12 +64,16 @@ function RequireAuth() {
 function AppRoutes() {
   const location = useLocation();
   const state = location.state as { background?: Location } | undefined;
+  const background =
+    state?.background && state.background.pathname !== location.pathname
+      ? state.background
+      : undefined;
   const modalMatches = ["/medical-records/new", "/medical-records/:id"];
   const isModalLocation = modalMatches.some((path) => matchPath(path, location.pathname));
 
   return (
     <>
-      <Routes location={state?.background || location}>
+      <Routes location={background || location}>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/admin/tenants" element={<TenantsAdmin />} />
         <Route element={<RequireAuth />}>
@@ -112,7 +116,7 @@ function AppRoutes() {
         <Route path="*" element={<NotFound />} />
       </Routes>
 
-      {(state?.background || isModalLocation) && (
+      {(background || isModalLocation) && (
         <Routes>
           <Route element={<RequireAuth />}>
             <Route

--- a/src/lib/api/historiasClinicas.ts
+++ b/src/lib/api/historiasClinicas.ts
@@ -78,8 +78,9 @@ export async function abrirHistoriaDesdeCita(citaId: number): Promise<HistoriaCl
   return mapHistoriaClinica(source);
 }
 
-export async function cerrarHistoria(historiaId: number): Promise<HistoriaClinica | null> {
-  const payload = await apiPost<any>(`/historias/cerrar/${historiaId}`);
+export async function cerrarHistoria(historiaId: number, motivo?: string | null): Promise<HistoriaClinica | null> {
+  const body = motivo && motivo.trim() !== "" ? { motivo: motivo.trim() } : {};
+  const payload = await apiPost<any>(`/historias-clinicas/${historiaId}/cerrar`, body);
   const source = payload?.historia ?? payload;
   return source ? mapHistoriaClinica(source) : null;
 }

--- a/src/lib/api/mappers.ts
+++ b/src/lib/api/mappers.ts
@@ -173,6 +173,7 @@ export const mapHistoriaClinica = (raw: any): HistoriaClinica => {
     estado: raw.estado ?? raw.estado_historia ?? null,
     fecha_cierre: raw.fecha_cierre ?? raw.fechaCierre ?? null,
     cerrada_por: toNumber(raw.cerrada_por ?? raw.cerradaPor ?? raw.cerrada_por_usuario) ?? null,
+    motivo_cierre: raw.motivo_cierre ?? raw.motivoCierre ?? null,
     detalles_generales: raw.detalles_generales ?? raw.detallesGenerales ?? raw.detalles ?? null,
     motivo_consulta: raw.motivo_consulta ?? raw.motivoConsulta ?? raw.motivo ?? null,
     fecha_creacion: raw.fecha_creacion ?? raw.fechaCreacion ?? raw.created_at ?? raw.createdAt ?? null,

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -849,7 +849,10 @@ const Appointments = () => {
                         <History className="mr-2 h-4 w-4" />
                         Historial
                       </Button>
-                      <Link to={`/appointments/${appointment.id_cita}`} state={{ background: location }}>
+                      <Link
+                        to={`/appointments/${appointment.id_cita}`}
+                        state={{ background: (location.state as any)?.background ?? location }}
+                      >
                         <Button variant="outline" size="sm">
                           <Eye className="mr-1 h-4 w-4" />
                           Ver

--- a/src/types/historiaClinica.ts
+++ b/src/types/historiaClinica.ts
@@ -9,6 +9,7 @@ export interface HistoriaClinica {
   estado?: string | null;
   fecha_cierre?: string | null;
   cerrada_por?: number | null;
+  motivo_cierre?: string | null;
   detalles_generales?: string | null;
   motivo_consulta?: string | null;
   fecha_creacion?: string | null;


### PR DESCRIPTION
Resumen

Incorpora la línea de tiempo de Cita que orquesta Historia 1:1 y Odontograma (draft→consolidar), añade cierre de Historia con motivo desde UI, y bloquea la edición cuando la Historia está CERRADA o el Odontograma está consolidado. Propaga version_token (If-Match) en mutaciones e invalida caches clave de React Query.

Cambios principales

CitaTimeline (/citas/:id/detalle)

Acciones: abrir/cerrar Historia, abrir Odontograma, publicar/descartar (si aplica), estado contextual.

Mensajería de bloqueo (solo lectura) cuando estado=CERRADA.

Invalida queries: ["cita", id], ["historia-by-cita", id], ["odontograma", historiaId].

API Layer / Types

src/lib/api/historiasClinicas.ts: cerrarHistoria(id, { motivo_cierre }).

src/lib/api/odontograma.ts: envío de If-Match con version_token, descartar, consolidar.

src/lib/api/mappers.ts / src/types/historiaClinica.ts: tipado de estado, motivo_cierre, campos de cierre.

UI/UX

Banner/labels de BORRADOR vs CONSOLIDADO.

Deshabilitar botones en modo solo lectura (historia cerrada y/o consolidado).

Toasts y errores legibles (409 para bloqueos).

Cómo probar (smoke)

En /citas/:id/detalle, abrir Historia (si ya existe, idempotente).

Abrir Odontograma (draft), mutar pieza (FDI 11), consolidar.

Cerrar Historia con motivo → verificar botones bloqueados y mensajes.

Intentar mutar post-cierre → debe mostrar error (409) y mantener estado UI.

Referencia: docs/README_QA_Sprint_A.md (pasos 2–6).

Checklist

 Flujo completo sin recargar página (CitaTimeline).

 If-Match enviado en mutaciones con version_token cuando aplique.

 Estados de botones sincronizados con estado de Historia y is_draft.

 Mensajes de error/éxito claros; toasts no bloqueantes.

 Accesibilidad básica: focus visible, labels, aria en controles principales.

 Sin regresiones en vistas de Citas/Historia/Odontograma existentes.

Riesgos / Compatibilidad

Requiere backend con endpoints y permisos actualizados.

Posibles ajustes de styling menores en modalidades/diálogos.

Plan de rollback

Revertir PR.

Feature-flag enrutamiento a CitaTimeline si existía vista previa.

Notas

Dejar capturas en el PR (antes/después).

Agregar casos a e2e.todo.md cuando se integre el harness de pruebas.